### PR TITLE
Update Run.hx

### DIFF
--- a/Run.hx
+++ b/Run.hx
@@ -141,7 +141,11 @@ class Run {
 						'php.xml.${name}';
 					// All other/unknown classes
 					case 'self':
-						currentClass;
+						if (basePackage != null && basePackage != '') {
+							'${basePackage}.${currentClass}';
+						} else {
+							currentClass;
+						}
 					case className:
 						if (basePackage != null && basePackage != '') {
 							'${basePackage}.${className}';


### PR DESCRIPTION
When return type was set to `self` in PHP docblocks, the output
incorrectly omitted the haxe package name when expanding the class name.

I think this is the last change required for docblock-based type-matching.

I've updated the output from running against WordPress to show the current state of the tool at https://gist.github.com/diddledan/b8d3907788052deac00c94a028f507df (~12000 lines! :-o)

Signed-off-by: Daniel Llewellyn <daniel@bowlhat.net>