### PR TITLE
Update peg/Parser.hx

### DIFF
--- a/peg/Parser.hx
+++ b/peg/Parser.hx
@@ -267,7 +267,7 @@ class Parser {
 	static public function parseTypeFromConstValue(ctx:Context):PType {
 		var token = ctx.stream.next();
 		inline function skipToSeparator() {
-			ctx.stream.skipTo([T_COMMA, T_SEMICOLON, T_RIGHT_PARENTHESIS]);
+			ctx.stream.skipTo([T_COMMA, T_SEMICOLON, T_RIGHT_PARENTHESIS, T_DOUBLE_ARROW]);
 			ctx.stream.back();
 		}
 		return switch token.type {


### PR DESCRIPTION
Ensure that associative arrays (maps) don't break the parser

Later we can improve the type mapping but this at least prevents us from simply throwing our hands in the air

Example test case that failed before (abridged from WordPress):

```php
<?php

class Foo {
	public $test = array(
		'acap' => array(
			'port' => 674
		),
		'dict' => array(
			'port' => 2628
		),
		'file' => array(
			'ihost' => 'localhost'
		),
		'http' => array(
			'port' => 80,
			'ipath' => '/'
		),
		'https' => array(
			'port' => 443,
			'ipath' => '/'
		),
	);
}
```

Signed-off-by: Daniel Llewellyn <diddledan@ubuntu.com>